### PR TITLE
Update sceKernelWaitSignal and sceKernelSendSignal

### DIFF
--- a/include/psp2/kernel/threadmgr.h
+++ b/include/psp2/kernel/threadmgr.h
@@ -1142,23 +1142,20 @@ int sceKernelDeleteLwCond(SceKernelLwCondWork *pWork);
 int sceKernelSignalLwCond(SceKernelLwCondWork *pWork);
 int sceKernelWaitLwCond(SceKernelLwCondWork *pWork,  unsigned int *pTimeout);
 
-typedef struct SceKernelWaitSignalOptParam {
-    SceUInt32 unk;
-} SceKernelWaitSignalOptParam;
-
 /**
  * @brief Sleep current thread and wait for a signal. After it receives a signal, the thread wakes up.
  *
  * This is like a semphore with limit 1.
  * If signal was sent before and not consumed before, the function will immediately return.
- *
- * @param params - extra parameters
+ * @param unk0 unknown parameter. 0 can be used.
+ * @param delay the delay before wating for a signal
+ * @param timeout the timeout if it's null, it waits indefinitely.
  * @return 0 on success
  */
-int sceKernelWaitSignal(SceUInt32 unk0, SceUInt32 unk1, SceKernelWaitSignalOptParam *params);
+int sceKernelWaitSignal(SceUInt32 unk0, SceUInt32 delay, SceUInt32 *timeout);
 
 /**
- * @brief Send a signal to another thread specified by thid.
+ * @brief Send a signal to the thread specified by thid. Note that it can send a signal to the current thread as well.
  *
  * @param thid - the id of the thread to send a signal to
  * @return 0 on success


### PR DESCRIPTION
This includes some recent findings in these functions. It turned out there's no such thing as SceKernelWaitSignalOptParam and sendsignal can send signal to the current thread. Libult library uses only waitsignal, sendsignal, and arm atomic instructions to implement some lock-free data structures that are used to build up its complex coroutine task system or lightweight sync primitives. It doesn't use scekernellwmutex or scekernelsemaphore family at all.